### PR TITLE
Consolidate filename regexes for auto-mode-alist

### DIFF
--- a/just-ts-mode.el
+++ b/just-ts-mode.el
@@ -332,8 +332,6 @@ The function removes existing entries for the Just language in
 (provide 'just-ts-mode)
 
 ;;;###autoload
-(progn
-  (add-to-list 'auto-mode-alist '("/[Jj]ustfile\\'" . just-ts-mode))
-  (add-to-list 'auto-mode-alist '("\\.[Jj]ust\\(file\\)?\\'" . just-ts-mode)))
+(add-to-list 'auto-mode-alist '("/\\(?:\\.\\)?[jJ][uU][sS][tT][fF][iI][lL][eE]\\'" . just-ts-mode))
 
 ;;; just-ts-mode.el ends here


### PR DESCRIPTION
This consolidates the two additions to `'auto-mode-alist` into one.