### PR TITLE
Switch use of tab-width to just-ts-indent-offset

### DIFF
--- a/just-ts-mode.el
+++ b/just-ts-mode.el
@@ -277,7 +277,7 @@ nil for some reason."
 (defvar just-ts-indent-rules
   `((just
      ;; In a recipe, indent by tab-width.
-     (,#'just-ts-indent-in-recipe-body column-0 tab-width))))
+     (,#'just-ts-indent-in-recipe-body column-0 just-ts-indent-offset))))
 
 (defun just-ts-setup ()
   "Set up treesit for \"just-ts-mode\"."


### PR DESCRIPTION
It was weird to use two different tab widths.

Closes https://github.com/leon-barrett/just-ts-mode.el/issues/3